### PR TITLE
fix: `scrollIntoView` in `undoManager.setOnPop`

### DIFF
--- a/src/undo.ts
+++ b/src/undo.ts
@@ -89,8 +89,10 @@ export class UndoPluginValue implements PluginValue {
                 const headPos = head
                     ? this.doc!.getCursorPos(head).offset
                     : anchorPos;
+                const selection = EditorSelection.single(anchorPos, headPos);
                 this.view.dispatch({
-                    selection: EditorSelection.single(anchorPos, headPos),
+                    selection,
+                    effects: [EditorView.scrollIntoView(selection.ranges[0])],
                 });
             }, 0);
         });


### PR DESCRIPTION
This implementation mimics CodeMirror 6's default undo behavior (when only using `basicSetup`), with the following adjustments:

1. **For the user performing undo/redo:**
   - If the undo/redo action moves the selection out of the visible viewport, the editor will scroll to bring the selection into view.
   - When scrolling:
     - If the selection is ahead of the current viewport, the editor scrolls to position the selection at the first line of the viewport.
     - If the selection is behind the current viewport, the editor scrolls to position the selection at the last line of the viewport.

2. **For collaborative users (not performing undo/redo):**
   - No scrolling occurs, ensuring the editor's viewport remains unchanged for these users.
