### PR TITLE
improvement: configurable getTextFromDoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     },
     "scripts": {
         "build": "tsc",
-        "dev": "tsc --watch"
+        "dev": "tsc --watch",
+        "typecheck": "tsc --noEmit"
     },
     "keywords": [
         "loro",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { type Extension, Prec } from "@codemirror/state";
-import { Awareness, LoroDoc, UndoManager } from "loro-crdt";
+import { Awareness, LoroDoc, LoroText, UndoManager } from "loro-crdt";
 import {
     createCursorLayer,
     createSelectionLayer,
@@ -13,24 +13,36 @@ import {
 import { LoroSyncPluginValue } from "./sync.ts";
 import { keymap, ViewPlugin } from "@codemirror/view";
 import { undoKeyMap, undoManagerStateField, UndoPluginValue } from "./undo.ts";
+import { defaultGetTextFromDoc } from "./utils.ts";
 
 export { undo, redo } from "./undo.ts";
-export { getTextFromDoc } from "./sync.ts";
+
+export { defaultGetTextFromDoc as getTextFromDoc };
 
 /**
  * It is used to sync the document with the remote users.
- * 
+ *
  * @param doc - LoroDoc instance
  * @returns Extension
  */
-export const LoroSyncPlugin = (doc: LoroDoc): Extension => {
-    return ViewPlugin.define((view) => new LoroSyncPluginValue(view, doc));
+export const LoroSyncPlugin = (
+    doc: LoroDoc,
+    getTextFromDoc?: (doc: LoroDoc) => LoroText
+): Extension => {
+    return ViewPlugin.define(
+        (view) =>
+            new LoroSyncPluginValue(
+                view,
+                doc,
+                getTextFromDoc ?? defaultGetTextFromDoc
+            )
+    );
 };
 
 /**
  * LoroAwarenessPlugin is a plugin that adds awareness to the editor.
  * It is used to sync the cursor position and selection of the editor with the remote users.
- * 
+ *
  * @param doc - LoroDoc instance
  * @param awareness - Awareness instance
  * @param user - User info
@@ -41,7 +53,8 @@ export const LoroAwarenessPlugin = (
     doc: LoroDoc,
     awareness: Awareness,
     user: UserState,
-    getUserId?: () => string
+    getUserId?: () => string,
+    getTextFromDoc?: (doc: LoroDoc) => LoroText
 ): Extension[] => {
     return [
         remoteAwarenessStateField,
@@ -54,7 +67,8 @@ export const LoroAwarenessPlugin = (
                     doc,
                     user,
                     awareness as Awareness<AwarenessState>,
-                    getUserId
+                    getUserId,
+                    getTextFromDoc ?? defaultGetTextFromDoc
                 )
         ),
         ViewPlugin.define(
@@ -71,39 +85,51 @@ export const LoroAwarenessPlugin = (
 
 /**
  * LoroUndoPlugin is a plugin that adds undo/redo to the editor.
- * 
+ *
  * @param doc - LoroDoc instance
  * @param undoManager - UndoManager instance
  * @returns Extension[]
  */
 export const LoroUndoPlugin = (
     doc: LoroDoc,
-    undoManager: UndoManager
+    undoManager: UndoManager,
+    getTextFromDoc?: (doc: LoroDoc) => LoroText
 ): Extension[] => {
+    getTextFromDoc = getTextFromDoc ?? defaultGetTextFromDoc;
     return [
         undoManagerStateField.init(() => undoManager),
         Prec.high(keymap.of([...undoKeyMap])),
         ViewPlugin.define(
-            (view) => new UndoPluginValue(view, doc, undoManager)
+            (view) =>
+                new UndoPluginValue(view, doc, undoManager, getTextFromDoc)
         ),
     ];
 };
 
 export function LoroExtensions(
     doc: LoroDoc,
-    awareness?: { user: UserState; awareness: Awareness; getUserId?: () => string },
-    undoManager?: UndoManager
+    awareness?: {
+        user: UserState;
+        awareness: Awareness;
+        getUserId?: () => string;
+    },
+    undoManager?: UndoManager,
+    getTextFromDoc?: (doc: LoroDoc) => LoroText
 ): Extension {
+    getTextFromDoc = getTextFromDoc ?? defaultGetTextFromDoc;
+
     let extension = [
-        ViewPlugin.define((view) => new LoroSyncPluginValue(view, doc))
-            .extension,
+        ViewPlugin.define(
+            (view) => new LoroSyncPluginValue(view, doc, getTextFromDoc)
+        ).extension,
     ];
     if (undoManager) {
         extension = extension.concat([
             undoManagerStateField.init(() => undoManager),
             Prec.high(keymap.of([...undoKeyMap])),
             ViewPlugin.define(
-                (view) => new UndoPluginValue(view, doc, undoManager)
+                (view) =>
+                    new UndoPluginValue(view, doc, undoManager, getTextFromDoc)
             ).extension,
         ]);
     }
@@ -119,7 +145,8 @@ export function LoroExtensions(
                         doc,
                         awareness.user,
                         awareness.awareness as Awareness<AwarenessState>,
-                        awareness.getUserId
+                        awareness.getUserId,
+                        getTextFromDoc
                     )
             ),
             ViewPlugin.define(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,8 @@
+import type { LoroDoc, LoroText } from "loro-crdt";
+
+/**
+ * Get the text from the document
+ */
+export const defaultGetTextFromDoc = (doc: LoroDoc): LoroText => {
+    return doc.getText("codemirror");
+};


### PR DESCRIPTION
Configurable optional `getTextFromDoc`, falling back to the original `getTextFromDoc`.

This also fixes a bug when applying events that they should only be applied to when matching the `containerId`

Fixes #7 